### PR TITLE
Fix symbol terminator parsing: close if followed by ) or ]

### DIFF
--- a/grammars/pact.cson
+++ b/grammars/pact.cson
@@ -277,7 +277,7 @@
     'patterns': [
       {
         'begin': '\''
-        'end': '(?=\\s|[,:\"\'\.)])'
+        'end': '(?=\\s|[],:\"\'\.)])'
         'name': 'string.quoted.symbol.pact'
       }
     ]

--- a/grammars/pact.cson
+++ b/grammars/pact.cson
@@ -277,7 +277,7 @@
     'patterns': [
       {
         'begin': '\''
-        'end': '(?=\\s|[,:\"\'\.])'
+        'end': '(?=\\s|[,:\"\'\.)])'
         'name': 'string.quoted.symbol.pact'
       }
     ]


### PR DESCRIPTION
close the string if it's followed by )
otherwise it looks like the ) is part of the string. eg 'blad)
needs more testing because I don't know if it might have side effects.